### PR TITLE
Add pkgconfig to win

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,7 @@ cmake -G "NMake Makefiles" ^
   -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
   -D CMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
   -D BUILD_SHARED_LIBS:BOOL=ON ^
+  -D VERSION=%PKG_VERSION% ^
   ..
 
 echo "configured ..."

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,8 @@ about:
   home: https://sourceware.org/libffi/
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   summary: A Portable Foreign Function Interface Library
-
   description: |
     The libffi library provides a portable, high level programming interface
     to various calling conventions. This allows a programmer to call any

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - win_cmake.patch        # [win]
     - fix_w3264_masm.patch   # [win]
 build:
-  number: 3
+  number: 4
   run_exports:
     # good history: https://abi-laboratory.pro/tracker/timeline/libffi/
     - {{ pin_subpackage('libffi', "x.x") }}

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,6 +1,7 @@
 if not exist %LIBRARY_PREFIX%/bin/ffi-7.dll exit /b 1
 if not exist %LIBRARY_PREFIX%/lib/libffi.lib exit /b 1
 if not exist %LIBRARY_PREFIX%/lib/ffi.lib exit /b 1
+if not exist %LIBRARY_PREFIX%/lib/pkgconfig/libffi.pc exit /b 1
 if not exist %LIBRARY_PREFIX%/include/ffi.h exit /b 1
 if not exist %LIBRARY_PREFIX%/include/ffitarget.h exit /b 1
 echo "platform name"

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,6 +1,7 @@
 set -ex
 test -e $PREFIX/lib/libffi${SHLIB_EXT}
 test -e $PREFIX/lib/libffi.a
+test -e $PREFIX/lib/pkgconfig/libffi.pc
 test -e $PREFIX/include/ffi.h
 test -e $PREFIX/include/ffitarget.h
 cd $PWD/testsuite/libffi.bhaible

--- a/recipe/win_cmake.patch
+++ b/recipe/win_cmake.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 0000000..26cc2fd
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,61 @@
 +cmake_minimum_required(VERSION 2.8.8)
 +project(libffi C)
 +
@@ -60,11 +60,15 @@ index 0000000..26cc2fd
 +    ${CMAKE_BINARY_DIR}/include/ffi.h
 +    ${CMAKE_BINARY_DIR}/include/ffitarget.h
 +    DESTINATION include)
++
++install(FILES
++    ${CMAKE_LIBRARY_DIR}/pkgconfig/libffi.pc
++    DESTINATION lib/pkgconfig)
 diff --git a/configure_options.cmake b/configure_options.cmake
 index 0000000..849231c
 --- /dev/null
 +++ b/configure_options.cmake
-@@ -0,0 +1,335 @@
+@@ -0,0 +1,341 @@
 +include(CheckCSourceCompiles)
 +include(CheckCSourceRuns)
 +include(CheckFunctionExists)
@@ -87,6 +91,11 @@ index 0000000..849231c
 +set(PACKAGE_VERSION ${VERSION})
 +set(TARGET ${TARGET_PLATFORM})
 +set(LT_OBJDIR .libs/)
++set(prefix ../..)
++set(exec_prefix \${prefix})
++set(libdir \${exec_prefix}/lib)
++set(toolexeclibdir \${exec_prefix}/lib)
++set(includedir \${prefix}/include)
 +
 +check_type_size (size_t SIZEOF_SIZE_T)
 +
@@ -376,6 +385,7 @@ index 0000000..849231c
 +
 +configure_file(include/ffi.h.in ${CMAKE_BINARY_DIR}/include/ffi.h)
 +configure_file(include/fficonfig.h.in ${CMAKE_BINARY_DIR}/include/fficonfig.h)
++configure_file(libffi.pc.in ${CMAKE_LIBRARY_DIR}/pkgconfig/libffi.pc)
 +
 +foreach(ASM_PATH IN LISTS WIN_ASSEMBLY_LIST)
 +    get_filename_component(ASM_FILENAME "${ASM_PATH}" NAME_WE)


### PR DESCRIPTION
Windows was missing libffi.pc. This is a rebuild to add it.

https://anaconda.atlassian.net/browse/DSNC-4917